### PR TITLE
Fixes Unexpected end of JSON input

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -237,7 +237,7 @@ class BunServer implements RequestMethod {
     });
 
     // append body
-    const body: { [key: string]: any } = await req.json();
+    const body: { [key: string]: any } = req.body ? await req.json() : null;
     req.arrayBuffer;
     newReq.body = body;
     newReq.blob = req.blob();


### PR DESCRIPTION
Verifying the request's body value before executing .json()
Solving the following:
```
GET - /ping failed
236 |       newReq.query[k] = v;
237 |     });
238 | 
239 |     // append body
240 |     const body: { [key: string]: any } = await req.json();
                                                   ^                                                   
SyntaxError: Unexpected end of JSON input
```
Meant to solve #17 
