### PR TITLE
Middleware assignment

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -62,16 +62,6 @@ export class Router implements RequestMethod {
   }
 
   attach(globalPath: string) {
-    // TODO: check if this is still necessary
-    // seems to be redundant
-    //
-    // this.localMiddlewares.forEach((mid) => {
-    //   this.middlewares.push({
-    //     path: path.join(globalPath, mid.path),
-    //     middlewareFunc: mid.middlewareFunc,
-    //   });
-    // });
-
     for (const k in this.localRequestMap) {
       const method = k;
       const reqArr: Array<RequestTuple> = this.localRequestMap[k];

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -58,25 +58,25 @@ export class Router implements RequestMethod {
   }
 
   use(middleware: Handler) {
-    this.localMiddlewares.push({
-      path: "*",
-      middlewareFunc: middleware,
-    });
+    this.localMiddlewares.push(middleware);
   }
 
   attach(globalPath: string) {
-    this.localMiddlewares.forEach((mid) => {
-      this.middlewares.push({
-        path: path.join(globalPath, mid.path),
-        middlewareFunc: mid.middlewareFunc,
-      });
-    });
+    // TODO: check if this is still necessary
+    // seems to be redundant
+    //
+    // this.localMiddlewares.forEach((mid) => {
+    //   this.middlewares.push({
+    //     path: path.join(globalPath, mid.path),
+    //     middlewareFunc: mid.middlewareFunc,
+    //   });
+    // });
 
     for (const k in this.localRequestMap) {
       const method = k;
       const reqArr: Array<RequestTuple> = this.localRequestMap[k];
       reqArr.forEach((v, _) => {
-        this.requestMapFunc.apply(this, [method, path.join(globalPath, v.path), v.handler]);
+        this.requestMapFunc.apply(this, [method, path.join(globalPath, v.path), v.route.handler, v.route.middlewareFuncs]);
       });
     }
   }
@@ -85,31 +85,30 @@ export class Router implements RequestMethod {
     if (localPath === '/') {
       localPath = ''
     }
-    
-    for (let i = 0; i < handlers.length; ++i) {
-      const handler = handlers[i];
-      if (i == handlers.length - 1) {
-        this.submitToMap(method.toLowerCase(), localPath, handler);
-        break;
-      }
 
-      this.localMiddlewares.push({
-        path: localPath,
-        middlewareFunc: handler,
-      });
-    }
+    if (handlers.length < 1) return;
+    // Split the array
+    const middlewares = handlers.slice(0, -1); // Array with all elements except the last one
+    const handler = handlers[handlers.length - 1]; // Array with only the last element
+
+    this.submitToMap(method.toLowerCase(), localPath, handler, middlewares);
   }
 
-  private submitToMap(method: string, path: string, handler: Handler) {
+  private submitToMap(method: string, path: string, handler: Handler, middlewares: Middleware) {
     let targetMap: RequestTuple[] = this.localRequestMap[method];
     if (!targetMap) {
       this.localRequestMap[method] = [];
       targetMap = this.localRequestMap[method];
     }
 
+    const route = {
+      handler: handler,
+      middlewareFuncs: middlewares,
+    }
+
     targetMap.push({
       path,
-      handler,
+      route,
     });
   }
 }

--- a/src/server/request.ts
+++ b/src/server/request.ts
@@ -8,6 +8,11 @@ export type Handler = (
   err?: Error
 ) => void | Promise<any>;
 
+export type Route = (
+  handler: Handler,
+  middlewareFuncs: Handler[]
+) => void | Promise<any>;
+
 export type MiddlewareFunc = (
   req: Request,
   res: BunResponse,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -76,7 +76,7 @@ class BunServer implements RequestMethod {
     this.webSocketHandler = {
       message: msgHandler,
       open: extra?.open,
-      close: extra?.close, 
+      close: extra?.close,
       drain: extra?.drain,
     }
   }
@@ -107,10 +107,7 @@ class BunServer implements RequestMethod {
     // pass middleware or global error handler
     else {
       if (arg1.length === 3) {
-        this.middlewares.push({
-          path: "*",
-          middlewareFunc: arg1 as Handler,
-        });
+        this.middlewares.push(arg1 as Handler);
       } else if (arg1.length === 4) {
         this.errorHandlers.push(arg1 as Handler);
       }
@@ -149,53 +146,11 @@ class BunServer implements RequestMethod {
       async fetch(req1: Request) {
         const req: BunRequest = await that.bunRequest(req1);
         const res = that.responseProxy();
-        
+
         if (req.path.endsWith('/')) {
           req.path = req.path.slice(0, req.path.length)
         }
 
-        // middlewares handler
-        if (that.middlewares.length !== 0) {
-          const plainMid = that.middlewares.filter((mid) => mid.path === "*");
-          const chain = new Chain(req, res, plainMid);
-          chain.next();
-
-          if (res.isReady()) {
-            return res.getResponse();
-          }
-
-          if (!chain.isFinish()) {
-            throw new Error("Please call next() at the end of your middleware");
-          }
-        }
-
-        const middlewares = [];
-        for (let i = that.middlewares.length - 1; i >= 0; --i) {
-          const target = that.middlewares[i];
-          if (target.path === "*") {
-            continue;
-          }
-
-          if (target.path === req.path) {
-            middlewares.push(target);
-            break;
-          }
-        }
-
-        if (middlewares.length !== 0) {
-          const chain = new Chain(req, res, middlewares);
-          chain.next();
-
-          if (res.isReady()) {
-            return res.getResponse();
-          }
-
-          if (!chain.isFinish()) {
-            throw new Error("Please call next() at the end of your middleware");
-          }
-        }
-
-        // request handler
         const tree: TrieTree<string, Handler> =
           that.requestMap[req.method.toLowerCase()];
 
@@ -204,25 +159,52 @@ class BunServer implements RequestMethod {
         }
 
         const leaf = tree.get(req.path);
-        const handlers: Handler[] = leaf.node?.getHandlers();
-        // append req route params
-        req.params = leaf.routeParams;
 
         // fix (issue 4: unhandle route did not throw an error)
-        if (!handlers || handlers.length === 0) {
+        if (!leaf.node) {
           console.error(`Cannot ${req.method} ${req.path}`);
           res.status(404).send(`${req.method} ${req.path} with a 404`)
           return res.getResponse()
         }
 
-        // fix (issue 13) : How to make it work with async functions or Promises?
-        // fix where response data cannot be processed in promise block
-        for (let i = 0; i < handlers.length; ++i) {
-          const response = handlers[i].apply(that, [req, res]);
-          if (response instanceof Promise) {
-            await response;
+        // append req route params
+        req.params = leaf.routeParams;
+
+        // middlewares handler
+        if (that.middlewares.length !== 0) {
+          const chain = new Chain(req, res, that.middlewares);
+          chain.next();
+
+          if (res.isReady()) {
+            return res.getResponse();
+          }
+
+          if (!chain.isFinish()) {
+            throw new Error("Please call next() at the end of your middleware");
           }
         }
+
+        const handler: Handler[] = leaf.node?.getHandler();
+        const middlewares: Handler[] = leaf.node?.getMiddlewares();
+
+        const chain = new Chain(req, res, middlewares);
+        chain.next();
+
+        if (res.isReady()) {
+          return res.getResponse();
+        }
+
+        if (!chain.isFinish()) {
+          throw new Error("Please call next() at the end of your middleware");
+        }
+
+        // fix (issue 13) : How to make it work with async functions or Promises?
+        // fix where response data cannot be processed in promise block
+        const response = handler.apply(that, [req, res]);
+        if (response instanceof Promise) {
+          await response;
+        }
+
         return res.getResponse();
       },
       websocket: this.webSocketHandler,
@@ -301,26 +283,24 @@ class BunServer implements RequestMethod {
       key = ''
     }
 
-    for (let i = 0; i < handlers.length; ++i) {
-      const handler = handlers[i];
-      if (i == handlers.length - 1) {
-        this.submitToMap(method.toLowerCase(), path, handler);
-        break;
-      }
+    if (handlers.length < 1) return;
+    // Split the array
+    const middlewares = handlers.slice(0, -1);
+    const handler = handlers[handlers.length - 1];
 
-      this.middlewares.push({
-        path: key,
-        middlewareFunc: handler,
-      });
-    }
+    this.submitToMap(method.toLowerCase(), path, handler, middlewares);
   }
 
-  private submitToMap(method: string, path: string, handler: Handler) {
+  private submitToMap(method: string, path: string, handler: Handler, middlewares: Middleware) {
     let targetTree: TrieTree<string, Handler> = this.requestMap[method];
     if (!targetTree) {
       this.requestMap[method] = new TrieTree();
       targetTree = this.requestMap[method];
     }
-    targetTree.insert(path, handler);
+    const route = {
+      handler: handler,
+      middlewareFuncs: middlewares,
+    }
+    targetTree.insert(path, route);
   }
 }

--- a/src/server/trie-tree.ts
+++ b/src/server/trie-tree.ts
@@ -1,7 +1,7 @@
-import { Handler, RequestTuple, RouteRequestMapper } from "./request";
+import { Handler, Route, RequestTuple, RouteRequestMapper } from "./request";
 
 //import { encodeBase64, decodeBase64 } from "../utils/base64";
-export class TrieTree<k extends string, v extends Handler> {
+export class TrieTree<k extends string, v extends Route> {
   private readonly root: Node<k, v>;
 
   constructor() {
@@ -78,7 +78,6 @@ export class TrieTree<k extends string, v extends Handler> {
         return next;
       }
     }
-    
     return next;
   }
 
@@ -101,23 +100,27 @@ export interface TrieLeaf<k, v> {
 // node of trie tree
 class Node<k, v> {
   private readonly path?: string;
-  private readonly handlers: Handler[] = [];
+  private readonly handlers: Route = {};
   private readonly children: Node<k, v>[] = [];
 
   constructor(path?: string) {
     this.path = path;
   }
 
-  insertChild(handler: Handler) {
-    this.handlers.push(handler);
+  insertChild(handlers: Route) {
+    this.handlers = handlers;
   }
 
   getChildren(): Node<k, v>[] {
     return this.children;
   }
 
-  getHandlers(): Handler[] {
-    return this.handlers;
+  getHandler(): Handler {
+    return this.handlers.handler;
+  }
+
+  getMiddlewares(): Handler[] {
+    return this.handlers.middlewareFuncs
   }
 
   getPath(): string {

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -4,7 +4,7 @@ import { BunResponse } from "../server/response";
 export function Chain(req: BunRequest, res: BunResponse, middlewares: Middleware[]) {
     this.middlewares = middlewares.map((mid) => {
         return () => {
-            mid.middlewareFunc(req, res, this.next);
+            mid(req, res, this.next);
             return res.isReady();
         }
     });

--- a/test/no_handler_test.ts
+++ b/test/no_handler_test.ts
@@ -1,32 +1,32 @@
-// import server from '../src';
-// import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import server from '../src';
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 
-// const app = server();
+const app = server();
 
-// app.get('/test', (req, res) => {
-//     res.status(200).send('GET /');
-// });
+app.get('/test', (req, res) => {
+    res.status(200).send('GET /');
+});
 
-// //add error handler 
-// app.use((req, res, next, err) => {
-//     res.status(500).send('Err /err');
-// });
+//add error handler
+app.use((req, res, next, err) => {
+    res.status(500).send('Err /err');
+});
 
-// const BASE_URL = 'http://localhost:3000';
+const BASE_URL = 'http://localhost:5555';
 
-// describe('no handler test', () => {
-//     it('GET', async () => {
-//         const server = app.listen(3000, () => {
-//             console.log('App is listening on port 3000');
-//         });
-//         try {
-//             const res = await fetch(BASE_URL);
-//             expect(res.status).toBe(404);
-//             expect(await res.text()).toBe('GET / with a 404')
-//         } catch (e) {
-//             throw e;
-//         } finally {
-//             server.stop();
-//         }
-//     });
-// })
+describe('no handler test', () => {
+    it('GET', async () => {
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
+        });
+        try {
+            const res = await fetch(BASE_URL);
+            expect(res.status).toBe(404);
+            expect(await res.text()).toBe('GET / with a 404')
+        } catch (e) {
+            throw e;
+        } finally {
+            server.stop();
+        }
+    });
+})

--- a/test/no_handler_test.ts
+++ b/test/no_handler_test.ts
@@ -12,12 +12,13 @@ app.use((req, res, next, err) => {
     res.status(500).send('Err /err');
 });
 
-const BASE_URL = 'http://localhost:5555';
+const URL_PORT = 5555;
+const BASE_URL = `http://localhost:${URL_PORT}`;
 
 describe('no handler test', () => {
     it('GET', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -46,6 +46,8 @@ app.get('/mid', (req, res, next) => {
     res.status(200).send('Middleware /mid');
 }, (req, res) => { });
 
+app.get('/mid/nomid', (req, res) => { res.status(200).send('No middleware /mid/nomid')});
+
 app.get('/mid/path', (req, res, next) => {
     res.status(200).send('Middleware /mid/path');
 }, (req, res) => { });
@@ -239,21 +241,20 @@ describe('router-test', () => {
                 server.stop();
             }
         });
-        // Delete is not working for bun, check (issues-667)[https://github.com/oven-sh/bun/issues/677]
-        // it('DELETE', async () => {
-        //     const server = app.listen(5555, () => {
-        //         console.log(`App is listening on port ${URL_PORT}`);
-        //     });
-        //     try {
-        //         const res = await fetch(BASE_URL, { method: 'DELETE' });
-        //         expect(res.status).toBe(200);
-        //         expect(await res.text()).toBe('DELETE /')
-        //     } catch (e) {
-        //         throw e;
-        //     } finally {
-        //         server.stop();
-        //     }
-        // });
+        it('DELETE', async () => {
+            const server = app.listen(5555, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
+            });
+            try {
+                const res = await fetch(BASE_URL, { method: 'DELETE' });
+                expect(res.status).toBe(200);
+                expect(await res.text()).toBe('DELETE /')
+            } catch (e) {
+                throw e;
+            } finally {
+                server.stop();
+            }
+        });
         it('OPTIONS', async () => {
             const server = app.listen(URL_PORT, () => {
                 console.log(`App is listening on port ${URL_PORT}`);
@@ -372,7 +373,7 @@ describe('websocket test', () => {
 //         const server = app.listen(5555, () => {
 //             console.log(`App is listening on port ${URL_PORT}`);
 //         })
-
+//
 //         try {
 //             const res = await fetch(BASE_URL + '/some_random_route', { method: 'POST' });
 //             expect(res.status).toBe(500);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -46,6 +46,14 @@ app.get('/mid', (req, res, next) => {
     res.status(200).send('Middleware /mid');
 }, (req, res) => { });
 
+app.get('/mid/path', (req, res, next) => {
+    res.status(200).send('Middleware /mid/path');
+}, (req, res) => { });
+
+app.get('/mid/:id', (req, res, next) => {
+    res.status(200).send(`Middleware /mid/${req.params.id}`);
+}, (req, res) => { });
+
 app.get('/err', (req, res) => {
     throw new Error('Err');
 })
@@ -67,12 +75,13 @@ app.ws((ws, msg) => {
     }
 })
 
-const BASE_URL = 'http://localhost:5555';
+const URL_PORT = 5555;
+const BASE_URL = `http://localhost:${URL_PORT}`;
 
 describe('http test', () => {
     it('GET', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL);
@@ -85,8 +94,8 @@ describe('http test', () => {
         }
     });
     it('POST', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'POST' });
@@ -99,8 +108,8 @@ describe('http test', () => {
         }
     });
     it('PATCH', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'PATCH' });
@@ -113,8 +122,8 @@ describe('http test', () => {
         }
     });
     it('PUT', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'PUT' });
@@ -127,8 +136,8 @@ describe('http test', () => {
         }
     });
     it('DELETE', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'DELETE' });
@@ -141,8 +150,8 @@ describe('http test', () => {
         }
     });
     it('OPTIONS', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'OPTIONS' });
@@ -155,8 +164,8 @@ describe('http test', () => {
         }
     });
     it('HEAD', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL, { method: 'HEAD' });
@@ -175,8 +184,8 @@ describe('router-test', () => {
     const url = BASE_URL + '/route';
     it('/route', () => {
         it('GET', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url);
@@ -189,8 +198,8 @@ describe('router-test', () => {
             }
         });
         it('POST', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url, { method: 'POST' });
@@ -203,8 +212,8 @@ describe('router-test', () => {
             }
         });
         it('PATCH', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url, { method: 'PATCH' });
@@ -217,8 +226,8 @@ describe('router-test', () => {
             }
         });
         it('PUT', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url, { method: 'PUT' });
@@ -233,7 +242,7 @@ describe('router-test', () => {
         // Delete is not working for bun, check (issues-667)[https://github.com/oven-sh/bun/issues/677]
         // it('DELETE', async () => {
         //     const server = app.listen(5555, () => {
-        //         console.log('App is listening on port 5555');
+        //         console.log(`App is listening on port ${URL_PORT}`);
         //     });
         //     try {
         //         const res = await fetch(BASE_URL, { method: 'DELETE' });
@@ -246,8 +255,8 @@ describe('router-test', () => {
         //     }
         // });
         it('OPTIONS', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url, { method: 'OPTIONS' });
@@ -260,8 +269,8 @@ describe('router-test', () => {
             }
         });
         it('HEAD', async () => {
-            const server = app.listen(5555, () => {
-                console.log('App is listening on port 5555');
+            const server = app.listen(URL_PORT, () => {
+                console.log(`App is listening on port ${URL_PORT}`);
             });
             try {
                 const res = await fetch(url, { method: 'HEAD' });
@@ -278,8 +287,8 @@ describe('router-test', () => {
 
 describe('middleware test', () => {
     it('middleware /', async () => {
-        const server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
             const res = await fetch(BASE_URL + '/mid', { method: 'GET' });
@@ -291,15 +300,43 @@ describe('middleware test', () => {
             server.stop();
         }
     })
+    it('middleware / path', async () => {
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
+        });
+        try {
+            const res = await fetch(BASE_URL + '/mid/path', { method: 'GET' });
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('Middleware /mid/path')
+        } catch (e) {
+            throw e;
+        } finally {
+            server.stop();
+        }
+    })
+    it('middleware / param', async () => {
+        const server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
+        });
+        try {
+            const res = await fetch(BASE_URL + '/mid/15', { method: 'GET' });
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('Middleware /mid/15')
+        } catch (e) {
+            throw e;
+        } finally {
+            server.stop();
+        }
+    })
 })
 
 describe('websocket test', () => {
     it(('ws'), () => {
-        let server = app.listen(5555, () => {
-            console.log('App is listening on port 5555');
+        let server = app.listen(URL_PORT, () => {
+            console.log(`App is listening on port ${URL_PORT}`);
         });
         try {
-            const socket = new WebSocket("ws://localhost:5555");
+            const socket = new WebSocket(`ws://localhost:${URL_PORT}`);
             const msg = 'Hello world'
             // message is received
             socket.addEventListener("message", event => {
@@ -333,7 +370,7 @@ describe('websocket test', () => {
 // describe('Error test', () => {
 //     it('unhandle route', async () => {
 //         const server = app.listen(5555, () => {
-//             console.log('App is listening on port 5555');
+//             console.log(`App is listening on port ${URL_PORT}`);
 //         })
 
 //         try {
@@ -346,7 +383,7 @@ describe('websocket test', () => {
 //     });
 //     it('error /err', async () => {
 //         const server = app.listen(5555, () => {
-//             console.log('App is listening on port 5555');
+//             console.log(`App is listening on port ${URL_PORT}`);
 //         });
 //         try {
 //             const res = await fetch(BASE_URL + '/err', { method: 'GET' });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -50,7 +50,7 @@ app.get('/err', (req, res) => {
     throw new Error('Err');
 })
 
-//add error handler 
+//add error handler
 app.use((req, res, next, err) => {
     res.status(500).send('Err /err');
 });
@@ -67,12 +67,12 @@ app.ws((ws, msg) => {
     }
 })
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = 'http://localhost:5555';
 
 describe('http test', () => {
     it('GET', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL);
@@ -85,8 +85,8 @@ describe('http test', () => {
         }
     });
     it('POST', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'POST' });
@@ -99,8 +99,8 @@ describe('http test', () => {
         }
     });
     it('PATCH', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'PATCH' });
@@ -113,8 +113,8 @@ describe('http test', () => {
         }
     });
     it('PUT', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'PUT' });
@@ -127,8 +127,8 @@ describe('http test', () => {
         }
     });
     it('DELETE', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'DELETE' });
@@ -141,8 +141,8 @@ describe('http test', () => {
         }
     });
     it('OPTIONS', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'OPTIONS' });
@@ -155,8 +155,8 @@ describe('http test', () => {
         }
     });
     it('HEAD', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL, { method: 'HEAD' });
@@ -175,8 +175,8 @@ describe('router-test', () => {
     const url = BASE_URL + '/route';
     it('/route', () => {
         it('GET', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url);
@@ -189,8 +189,8 @@ describe('router-test', () => {
             }
         });
         it('POST', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url, { method: 'POST' });
@@ -203,8 +203,8 @@ describe('router-test', () => {
             }
         });
         it('PATCH', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url, { method: 'PATCH' });
@@ -217,8 +217,8 @@ describe('router-test', () => {
             }
         });
         it('PUT', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url, { method: 'PUT' });
@@ -232,8 +232,8 @@ describe('router-test', () => {
         });
         // Delete is not working for bun, check (issues-667)[https://github.com/oven-sh/bun/issues/677]
         // it('DELETE', async () => {
-        //     const server = app.listen(3000, () => {
-        //         console.log('App is listening on port 3000');
+        //     const server = app.listen(5555, () => {
+        //         console.log('App is listening on port 5555');
         //     });
         //     try {
         //         const res = await fetch(BASE_URL, { method: 'DELETE' });
@@ -246,8 +246,8 @@ describe('router-test', () => {
         //     }
         // });
         it('OPTIONS', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url, { method: 'OPTIONS' });
@@ -260,8 +260,8 @@ describe('router-test', () => {
             }
         });
         it('HEAD', async () => {
-            const server = app.listen(3000, () => {
-                console.log('App is listening on port 3000');
+            const server = app.listen(5555, () => {
+                console.log('App is listening on port 5555');
             });
             try {
                 const res = await fetch(url, { method: 'HEAD' });
@@ -278,8 +278,8 @@ describe('router-test', () => {
 
 describe('middleware test', () => {
     it('middleware /', async () => {
-        const server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        const server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
             const res = await fetch(BASE_URL + '/mid', { method: 'GET' });
@@ -295,11 +295,11 @@ describe('middleware test', () => {
 
 describe('websocket test', () => {
     it(('ws'), () => {
-        let server = app.listen(3000, () => {
-            console.log('App is listening on port 3000');
+        let server = app.listen(5555, () => {
+            console.log('App is listening on port 5555');
         });
         try {
-            const socket = new WebSocket("ws://localhost:3000");
+            const socket = new WebSocket("ws://localhost:5555");
             const msg = 'Hello world'
             // message is received
             socket.addEventListener("message", event => {
@@ -332,8 +332,8 @@ describe('websocket test', () => {
 // Delete this test because bun test would stop if any error throws, global handlers won't able to stop the throwing
 // describe('Error test', () => {
 //     it('unhandle route', async () => {
-//         const server = app.listen(3000, () => {
-//             console.log('App is listening on port 3000');
+//         const server = app.listen(5555, () => {
+//             console.log('App is listening on port 5555');
 //         })
 
 //         try {
@@ -345,8 +345,8 @@ describe('websocket test', () => {
 //         }
 //     });
 //     it('error /err', async () => {
-//         const server = app.listen(3000, () => {
-//             console.log('App is listening on port 3000');
+//         const server = app.listen(5555, () => {
+//             console.log('App is listening on port 5555');
 //         });
 //         try {
 //             const res = await fetch(BASE_URL + '/err', { method: 'GET' });

--- a/test/server.ts
+++ b/test/server.ts
@@ -83,6 +83,6 @@ router.options('/test', async (req, res) => {
 
 app.use('/', router);
 
-app.listen(3000, () => {
+app.listen(5555, () => {
   console.log('App is listening on port 3000')
 })

--- a/test/server.ts
+++ b/test/server.ts
@@ -67,6 +67,8 @@ import server from "../index";
 const app = server()
 const router = app.router()
 
+const URL_PORT = 5555;
+
 app.get("/user", (req, res) => {
   res.status(200).json(req.body);
 });
@@ -83,6 +85,6 @@ router.options('/test', async (req, res) => {
 
 app.use('/', router);
 
-app.listen(5555, () => {
+app.listen(URL_PORT, () => {
   console.log('App is listening on port 3000')
 })

--- a/test/trie.test.ts
+++ b/test/trie.test.ts
@@ -1,22 +1,22 @@
 // import { describe, it, expect } from "bun:test";
-// import { TrieTree } from "../index";
-
+// import { TrieTree } from "../src/server/trie-tree";
+//
 // describe('data container test', () => {
 //     it('trie tree test', () => {
 //         const tree: TrieTree<string, number> = new TrieTree();
 //         tree.insert('GET-/', 1);
 //         expect(tree.get('GET-/')?.node.getValue()).toBe(1);
 //         expect(tree.get('GET-/xx')?.node?.getValue()).toBe(undefined);
-
+//
 //         tree.insert('GET-/test1/:id', 2);
 //         expect(tree.get('GET-/test1/xxx')?.node.getValue()).toBe(2);
-
+//
 //         tree.insert('POST-/test2', 3);
 //         expect(tree.get('POST-/test2')?.node.getValue()).toBe(3);
-
+//
 //         tree.insert('POST-/test1/test1', 4);
 //         expect(tree.get('POST-/test1/test1')?.node.getValue()).toBe(4);
-
+//
 //         tree.insert('POST-/test2/test2', 5);
 //         expect(tree.get('POST-/test2/test2')?.node.getValue()).toBe(5);
 //     });


### PR DESCRIPTION
Middleware belonging to a route now get assigned to that route instead of getting stored in a global list making it impossible for middleware to run on a route it doesn't belong to.
This also fixes the issue mentioned in #39 