### PR TITLE
Add reusePort to listen SSLOptions

### DIFF
--- a/src/server/request.ts
+++ b/src/server/request.ts
@@ -51,6 +51,7 @@ export interface BunRequest {
 }
 
 export interface SSLOptions {
+  reusePort: boolean;
   keyFile: string;
   certFile: string;
   passphrase?: string;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -136,6 +136,7 @@ class BunServer implements RequestMethod {
     const that = this;
     return Bun.serve({
       port,
+      reusePort: options?.reusePort,
       keyFile: options?.keyFile,
       certFile: options?.certFile,
       passphrase: options?.passphrase,


### PR DESCRIPTION
This allows bunrest to function seamlessly in multithreaded workloads, leveraging the capability provided by Bun.spawn().


```typescript
// spawn.ts
import { availableParallelism } from 'node:os'
import process from 'node:process'

const numCPUs = availableParallelism();

for (let i = 0; i < numCPUs; i++) {
  Bun.spawn(["bun", "index.ts"], {
    stdio: ["inherit", "inherit", "inherit"],
    env: { ...process.env },
  });
}
```

```typescript
// index.ts
import server from 'bunrest'
const app = server()

app.get('/', (req, res) => {
  res.status(200).send('Hello, World!');
})

app.listen(3000, () => {
  console.log('App is listening on port 3000');
}, {
  reusePort: true
})
```